### PR TITLE
feat: similarity search complement and test

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,6 +1,3 @@
-pub mod searchcache;
 pub mod vectorindex;
 
-
-pub use searchcache::{SearchCache, create_search_cache};
 pub use vectorindex::{VectorIndex, create_vector_index};

--- a/src/components/searchcache.rs
+++ b/src/components/searchcache.rs
@@ -1,8 +1,20 @@
 use lru::LruCache;
 use std::num::NonZeroUsize;
 
+
+// --- 2. LRU 쿼리 캐시 타입 정의 ---
+
+/// 검색 쿼리 결과를 저장하는 LRU 캐시의 타입 별칭입니다.
+///
+/// - 제네릭 `<u64, Vec<(u64, f32)>>`:
+///   - `Key (u64)`: 검색어 벡터(`query_vector`)를 해싱한 `u64` 값입니다.
+///   - `Value (Vec<(u64, f32)>)`: 검색 결과. 유사도가 높은 문서들의 `(ID, 유사도 점수)` 튜플의 목록입니다.
 pub type SearchCache = LruCache<u64, Vec<(u64, f32)>>;
 
+/// LRU 캐시를 생성하는 팩토리 함수입니다.
+///
+/// # 인자
+/// - `capacity`: 캐시가 저장할 수 있는 최대 항목 수
 pub fn create_search_cache(capacity: usize) -> SearchCache {
     // 용량이 0이 되는 것을 방지하고 기본값 설정
     let non_zero_capacity = NonZeroUsize::new(capacity)

--- a/src/components/vectorindex.rs
+++ b/src/components/vectorindex.rs
@@ -11,5 +11,5 @@ pub fn create_vector_index() -> VectorIndex<'static> {
     // ef_construction: 검색 품질/속도 트레이드오프 파라미터
     // capacity: 예상되는 데이터의 최대 개수
     // distance: 거리 계산 방식 인스턴스
-    Hnsw::new(16, 32, 200, 1000, DistCosine)
+    Hnsw::new(16, 32, 200, 500, DistCosine)
 }

--- a/src/models/engine.rs
+++ b/src/models/engine.rs
@@ -1,11 +1,13 @@
-use std::{collections::HashMap, vec};
-use crate::components::{
-    SearchCache, VectorIndex, create_search_cache, create_vector_index
+use std::{collections::HashMap};
+use crate::{components::{
+    create_vector_index, VectorIndex}, 
+    utils::hash_vector, 
+    models::{SearchCache, CacheStats}
 };
 
 pub struct VectorEngine<'a> {
     index: VectorIndex<'a>,
-    query_cache: SearchCache,
+    query_cache: SearchCache<'a, u64, Vec<(u64, f32)>>,
     dimension: usize,
     documents: HashMap<u64, Vec<f32>>,
 }
@@ -16,9 +18,19 @@ impl<'a> VectorEngine<'a> {
         VectorEngine {
             dimension,
             index: create_vector_index(),
-            query_cache: create_search_cache(100),
+            query_cache: SearchCache::new(100),
             documents: HashMap::new()
         }
+    }
+
+    /// 테스트 목적으로 캐시에 저장된 항목의 수를 반환합니다.
+    pub fn query_cache_len(&self) -> usize {
+        self.query_cache.len()
+    }
+
+    /// 테스트 목적으로 캐시의 히트/미스 통계를 반환합니다.
+    pub fn query_cache_stats(&self) -> &CacheStats {
+        self.query_cache.stats()
     }
 
     pub fn document_count(&self) -> usize {
@@ -45,6 +57,47 @@ impl<'a> VectorEngine<'a> {
         // documents 해시에 추가
         self.documents.insert(id, vector);
 
+        // 캐시 초기화하여 캐시 데이터 일관성 유지
+        self.query_cache.clear();
+
         Ok(())
+    }
+
+    pub fn search(&mut self, query_vector: &Vec<f32>, top_k: usize) -> Result<Vec<(u64, f32)>, String> {
+        // 1. 차원 검사
+        if self.dimension != query_vector.len() {
+            return Err(format!(
+                "쿼리 벡터의 차원({})이 엔진의 차원({})과 일치하지 않습니다.",
+                query_vector.len(),
+                self.dimension
+            ));
+        }
+
+        // 2. 캐시 키 생성
+        let hash_id: u64 = hash_vector(query_vector);
+
+        // 3. 캐시 검색 (Hit)
+        if let Some(cached_results) = self.query_cache.get(&hash_id) {
+            return Ok(cached_results.clone());
+        }
+
+        // Cache Miss 로직
+        // 4. HNSW에서 검색 수행
+        let search_result_neighbors = self.index.search(query_vector, top_k, top_k*3);
+
+        // 5. 검색 결과를 (u64, f32) 튜플 형태로 변환
+        let mut results: Vec<(u64, f32)> = search_result_neighbors
+            .into_iter()
+            .map(|neighbor| (neighbor.d_id as u64, neighbor.distance))
+            .collect();
+
+        // 5-1. 유사도를 기준으로 높은 순으로 정렬
+        results.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+
+        // 6. 캐시에 새로운 검색 결과 저장
+        self.query_cache.put(hash_id, results.clone());
+
+        // 7. 최종 결과 반환
+        Ok(results)
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,5 +1,7 @@
 pub mod document;
 pub mod engine;
+pub mod search_cache;
 
 pub use document::Document;
 pub use engine::VectorEngine;
+pub use search_cache::{SearchCache, CacheStats};

--- a/src/models/search_cache.rs
+++ b/src/models/search_cache.rs
@@ -1,0 +1,74 @@
+use lru::LruCache;
+use std::num::NonZeroUsize;
+
+#[derive(Default, Debug)]
+pub struct CacheStats {
+    pub hits: u64,
+    pub misses: u64
+}
+
+pub struct SearchCache<'a, K: std::hash::Hash + Eq, V> {
+    cache: LruCache<K, V>,
+    stats: CacheStats,
+    _phantom: std::marker::PhantomData<&'a ()>
+}
+
+impl<'a, K: std::hash::Hash + Eq, V> SearchCache<'a, K, V> {
+    /// 통계 기능이 추가된 새 캐시를 생성합니다.
+    pub fn new(capacity: usize) -> Self {
+        // 용량이 0이 되는 것을 방지
+        let non_zero_capacity = NonZeroUsize::new(capacity)
+            .unwrap_or_else(|| NonZeroUsize::new(1).unwrap()); // 0일 경우 기본값 1
+
+        SearchCache {
+            cache: LruCache::new(non_zero_capacity),
+            stats: CacheStats::default(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// 데이터를 추가합니다. (내부 캐시의 put 호출)
+    pub fn put(&mut self, key: K, value: V) -> Option<V> {
+        self.cache.put(key, value)
+    }
+
+    /// 데이터를 조회하며 히트/미스를 기록합니다.
+    pub fn get(&mut self, key: &K) -> Option<&V> {
+        let result = self.cache.get(key);
+        if result.is_some() {
+            self.stats.hits += 1;
+        } else {
+            self.stats.misses += 1;
+        }
+        result
+    }
+
+    pub fn contains(&self, key: &K) -> bool {
+        self.cache.contains(key)
+    }
+
+    /// 현재 히트율을 백분율(%)로 계산하여 반환합니다.
+    pub fn hit_rate(&self) -> f64 {
+        let total = self.stats.hits + self.stats.misses;
+        if total == 0 {
+            0.0
+        } else {
+            (self.stats.hits as f64 / total as f64) * 100.0
+        }
+    }
+
+    /// 현재 통계 정보를 반환합니다.
+    pub fn stats(&self) -> &CacheStats {
+        &self.stats
+    }
+
+    /// 현재 캐시 내부 요소 개수를 반환합니다.
+    pub fn len(&self) -> usize {
+        self.cache.len()
+    }
+
+    /// 캐시를 초기화합니다.
+    pub fn clear(&mut self) {
+        self.cache.clear();
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use ahash::AHasher;
 use std::hash::{Hasher};
+use wasm_bindgen::prelude::*;
 
 
 /// 주어진 벡터에 대해 고유한 해시 키를 생성합니다.
@@ -9,7 +10,8 @@ use std::hash::{Hasher};
 ///
 /// # 반환값
 /// - `u64`: 해시 키
-pub fn hash_vector(vec: &Vec<f32>) -> u64 {
+#[wasm_bindgen]
+pub fn hash_vector(vec: &[f32]) -> u64 {
     let mut hasher = AHasher::default();
     // f32를 직접 해싱할 수 없어, 비트 표현을 u32로 변환하여 해싱
     for &v in vec.iter() {

--- a/tests/vector_engine_test.rs
+++ b/tests/vector_engine_test.rs
@@ -53,3 +53,138 @@ fn test_vector_engine_add_document_dif_dimension() {
     // ! 실패 후 문서 개수가 여전히 0인지 확인
     assert_eq!(engine.document_count(), 0);
 }
+
+// VectorEngine Search 함수 테스트
+#[test]
+fn test_vector_engine_search_hit() {
+    // 벡터엔진 준비
+    let dimension = 3;
+    let mut engine = VectorEngine::new(dimension);
+
+    // 테스트를 위해 예측 가능한 ID를 사용합니다.
+    let id1 = 1;
+    let id2 = 2;
+    let id3 = 3;
+    let id4 = 4;
+
+    let input_vector1: Vec<f32> = vec![0.1, 0.2, 0.3];
+    let input_vector2: Vec<f32> = vec![0.9, 0.8, 0.7]; // query_vector와 가장 유사한 벡터
+    let input_vector3: Vec<f32> = vec![0.2, 0.4, 0.5];
+    let input_vector4: Vec<f32> = vec![0.2, 0.5, 0.6];
+    
+    // 검색할 기준 벡터. input_vector2와 거의 동일하게 설정합니다.
+    let query_vector: Vec<f32> = vec![0.9, 0.8, 0.71];
+
+    // 벡터 입력
+    engine.add_document(id1, input_vector1).unwrap();
+    engine.add_document(id2, input_vector2).unwrap();
+    engine.add_document(id3, input_vector3).unwrap();
+    engine.add_document(id4, input_vector4).unwrap();
+
+
+    // 검색 시작
+    let top_k = 4;
+    let results = engine.search(&query_vector, top_k);
+
+    // 검색 성공했는지
+    assert!(results.is_ok());
+    let search_results = results.unwrap();
+
+    // 1. 요청한 개수(top_k)만큼 결과가 반환되었는지
+    assert_eq!(search_results.len(), top_k);
+
+    // 2. 가장 유사한 결과 (0번 인덱스)의 ID가 예상대로 id 2인지
+    assert_eq!(search_results[0].0, id2);
+    println!("Search Results (ID, Distance): {:?}", search_results);
+}
+
+
+#[test]
+fn test_vector_engine_search_miss() {
+    // 1. 준비 (Arrange)
+    let mut engine = VectorEngine::new(3);
+    engine.add_document(1, vec![0.1, 0.2, 0.3]).unwrap();
+    engine.add_document(2, vec![0.9, 0.8, 0.7]).unwrap();
+    let query_vector = vec![0.8, 0.8, 0.8];
+
+    // 실행 전, 캐시는 비어있고 통계는 모두 0이어야 함
+    assert_eq!(engine.query_cache_len(), 0);
+    assert_eq!(engine.query_cache_stats().hits, 0);
+    assert_eq!(engine.query_cache_stats().misses, 0);
+
+    // 2. 첫 번째 검색 (Act 1 - Cache Miss)
+    let first_result = engine.search(&query_vector, 1).unwrap();
+
+    // 3. 검증 (Assert 1)
+    // 캐시 미스가 1 증가하고, 캐시에 결과가 저장되어야 함
+    assert_eq!(engine.query_cache_stats().misses, 1);
+    assert_eq!(engine.query_cache_len(), 1);
+    assert_eq!(first_result[0].0, 2); // 가장 가까운 벡터는 ID 2
+
+    // 4. 두 번째 검색 (Act 2 - Cache Hit)
+    let second_result = engine.search(&query_vector, 1).unwrap();
+
+    // 5. 검증 (Assert 2)
+    // 캐시 히트가 1 증가하고, 미스는 그대로여야 함
+    assert_eq!(engine.query_cache_stats().hits, 1);
+    assert_eq!(engine.query_cache_stats().misses, 1);
+    // 두 결과는 동일해야 함
+    assert_eq!(first_result, second_result);
+}
+
+#[test]
+fn test_vector_engine_search_on_empty_engine() {
+    // 준비
+    let mut engine = VectorEngine::new(3);
+    let query_vector = vec![0.1, 0.2, 0.3];
+
+    // 실행
+    let results = engine.search(&query_vector, 3);
+
+    // 검증
+    assert!(results.is_ok());
+    // 결과 벡터가 비어있는지 확인
+    assert!(results.unwrap().is_empty());
+}
+
+#[test]
+fn test_vector_engine_search_with_k_larger_than_docs() {
+    // 준비
+    let mut engine = VectorEngine::new(3);
+    // 방향이 서로 다른 벡터들을 추가
+    engine.add_document(1, vec![1.0, 0.1, 0.2]).unwrap(); // x축에 가까움
+    engine.add_document(2, vec![0.1, 1.0, 0.3]).unwrap(); // y축에 가까움
+    engine.add_document(3, vec![0.2, 0.1, 1.0]).unwrap(); // z축에 가까움
+    
+    // ID 1의 벡터와 가장 유사한 쿼리 벡터
+    let query_vector = vec![0.9, 0.0, 0.1];
+
+    // 실행
+    let results = engine.search(&query_vector, 3).unwrap();
+
+    // 검증
+    assert_eq!(results.len(), 3);
+    // 가장 가까운 결과(거리가 가장 작은 결과)는 ID 1이어야 함
+    assert_eq!(results[0].0, 1);
+}
+
+#[test]
+fn test_vector_engine_search_after_cache_invalidation() {
+    // 준비
+    let mut engine = VectorEngine::new(3);
+    engine.add_document(1, vec![0.1, 0.1, 0.1]).unwrap(); // 덜 유사한 벡터
+    let query_vector = vec![0.9, 0.9, 0.9];
+
+    // 첫 번째 검색 -> ID 1이 캐시에 저장됨
+    let first_results = engine.search(&query_vector, 1).unwrap();
+    assert_eq!(first_results[0].0, 1);
+
+    // 훨씬 더 유사한 새 벡터 추가 -> 이 때 캐시가 비워져야 함
+    engine.add_document(2, vec![0.8, 0.8, 0.8]).unwrap();
+    
+    // 다시 검색
+    let second_results = engine.search(&query_vector, 1).unwrap();
+
+    // 검증: 캐시의 낡은 데이터가 아닌, 새로 추가된 ID 2가 반환되어야 함
+    assert_eq!(second_results[0].0, 2);
+}


### PR DESCRIPTION
구현 완료

### 📝 개요 (Overview)
> 이번 PR의 목표는 무엇인가요? 어떤 User Story를 해결하나요?

VectorEngine으로서, 나는 쿼리 벡터(query_vector)와 top_k 값을 받아, LRU 캐시와 HNSW 인덱스를 효율적으로 사용하여 의미적으로 가장 유사한 k개의 문서 ID와 유사도 점수를 반환할 수 있어야 한다.

### 🔨 주요 변경 사항 (Key Changes)
> 구체적으로 어떤 파일에서 무엇을 변경했나요?

- 기존의 components에서 Type으로 선언한 search_cache를 models의 SearchCache 구조체로 변경
- SearchCache 구조체 내부에 성능 측정을 위한 hit, miss를 가지는 구조체 CacheStats 생성
- VectorEngine의 유사도 검색 메서드 search(query_vector, top_k)를 구현
- test/vector_engine_test.rs에서 search(query_vector, top_k)를 테스트


### ✅ 관련 이슈 또는 User Story
> 이 PR이 해결하는 칸반 보드의 User Story는 무엇인가요? (예: Closes: #이슈번호)

- Closes: **[스프린트 2]** 유사도 검색 기능 `Y`


### 📸 스크린샷 또는 로그 (Screenshots or Logs)
> 테스트 결과나 UI 변경사항 등, 시각적으로 보여줄 수 있는 증거가 있나요?

```bash
Running tests\vector_engine_test.rs (target\debug\deps\vector_engine_test-df146d14065813bf.exe)

running 8 tests
test test_vector_engine_search_after_cache_invalidation ... ok
test test_vector_engine_add_document_success ... ok
test test_vector_engine_search_on_empty_engine ... ok
test test_vector_engine_search_miss ... ok
test test_vector_engine_creation ... ok
test test_vector_engine_add_document_dif_dimension ... ok
test test_vector_engine_search_hit ... ok
test test_vector_engine_search_with_k_larger_than_docs ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```