### PR TITLE
engine binary serialization 구현

### DIFF
--- a/src/models/engine.rs
+++ b/src/models/engine.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap};
+use prost::Message;
+
 use crate::{components::{
-    create_vector_index, VectorIndex}, 
-    utils::hash_vector, 
-    models::{SearchCache, CacheStats}
+    create_vector_index, VectorIndex}, models::{document::{EngineState, Document}, CacheStats, SearchCache}, utils::hash_vector
 };
 
 pub struct VectorEngine<'a> {
@@ -39,6 +39,11 @@ impl<'a> VectorEngine<'a> {
 
     pub fn dimension(&self) -> usize {
         self.dimension
+    }
+    
+    /// 엔진에 저장된 documents 해시맵의 불변 참조를 반환합니다.
+    pub fn  documents(&self) -> &HashMap<u64, Vec<f32>> {
+        &self.documents
     }
 
     pub fn add_document(&mut self, id: u64, vector: Vec<f32>) -> Result<(), String> {
@@ -99,5 +104,48 @@ impl<'a> VectorEngine<'a> {
 
         // 7. 최종 결과 반환
         Ok(results)
+    }
+
+    pub fn save_to_bytes(&self) -> Result<Vec<u8>, String> {
+        // 1. engine의 documents 해시맵을 벡터로 변환
+        let documents_to_save = self.documents
+            .iter()
+            .map(|(&id, vector)| {
+                Document {
+                    id,
+                    vector: vector.clone(),
+                }
+            })
+            .collect();
+        
+        // 2. 변환된 데이터를 포함하는 EngineState 인스턴스 생성
+        let current_engine_state: EngineState = EngineState {
+            format_version: 1,
+            documents: documents_to_save,
+        };
+
+        // 3. EngineState를 바이트 배열로 직렬화
+        let mut buf: Vec<u8> = Vec::new();
+        current_engine_state.encode(&mut buf).map_err(|e| e.to_string())?;
+        
+        // 4. 직렬화된 바이트 벡터 반환
+        Ok(buf)
+    }
+
+    pub fn load_from_bytes(bytes: &[u8], dimension: usize) -> Result<VectorEngine<'static>, String> {
+        // 1. byte 슬라이스를 EngineState 구조체로 디코딩
+        let state = EngineState::decode(bytes).map_err(|e| e.to_string())?;
+
+        // 2. 새로운 VectorEngine 인스턴스 생성
+        let mut engine: VectorEngine<'static> = VectorEngine::new(dimension);
+
+        // 3. 복원된 document목록을 순회하며 엔진에 추가
+        for doc in state.documents {
+            // add_document가 Result를 반환하므로 ?로 에러 처리
+            engine.add_document(doc.id, doc.vector)?;
+        }
+        
+        // 4. 복원 완료된 엔진 반환
+        Ok(engine)
     }
 }


### PR DESCRIPTION
구현 완료

### 📝 개요 (Overview)
> 이번 PR의 목표는 무엇인가요? 어떤 User Story를 해결하나요?

**User Story:** `VectorEngine`으로서, 나는 현재의 모든 **지속성 상태(Persistent State)**를 하나의 바이트 배열(`Vec<u8>`)로 내보내는(`save`) 기능과, 바이트 배열로부터 엔진의 상태를 완벽하게 복원하는(`load`) 기능을 제공해야 한다.

### 🔨 주요 변경 사항 (Key Changes)
> 구체적으로 어떤 파일에서 무엇을 변경했나요?

- engine.rs에서 VectorEngine에 documents의 getter 생성
- engine.rs에서 VectorEngine에 save_to_bytes, load_from_bytes 구현
- vector_engine_test.rs에서 직렬화 테스트 구현


### ✅ 관련 이슈 또는 User Story
> 이 PR이 해결하는 칸반 보드의 User Story는 무엇인가요? (예: Closes: #이슈번호)

- Closes: **[스프린트 2]** 바이너리 저장소 연동


### 📸 스크린샷 또는 로그 (Screenshots or Logs)
> 테스트 결과나 UI 변경사항 등, 시각적으로 보여줄 수 있는 증거가 있나요?

```bash
Running tests\vector_engine_test.rs (target\debug\deps\vector_engine_test-df146d14065813bf.exe)

running 11 tests
test test_vector_engine_serialization ... ok
test test_vector_engine_search_with_k_larger_than_docs ... ok
test test_vector_engine_search_after_cache_invalidation ... ok
test test_vector_engine_add_document_dif_dimension ... ok
test test_vector_engine_creation ... ok
test test_vector_engine_round_trip ... ok
test test_vector_engine_search_miss ... ok
test test_vector_engine_search_hit ... ok
test test_vector_engine_search_on_empty_engine ... ok
test test_vector_engine_add_document_success ... ok
test test_vector_engine_deserialization ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```