### PR TITLE
error enum 생성 및 테스트

### DIFF
--- a/benches/engine_benchmark.rs
+++ b/benches/engine_benchmark.rs
@@ -45,7 +45,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let query_vector = generate_random_data(1).pop().unwrap().1;
         
         b.iter(|| {
-            engine.search(black_box(&query_vector), black_box(10))
+            engine.search(black_box(&query_vector), black_box(10), black_box(30))
         });
     });
 
@@ -66,7 +66,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             },
             // 준비된 엔진에서 update 메서드만 실행하여 시간 측정
             |mut engine| {
-                engine.update_document(black_box(&update_id), black_box(new_vector.clone())).unwrap();
+                engine.update_document(black_box(&update_id), black_box(new_vector.clone()));
             }
         );
     });
@@ -88,7 +88,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             },
             // 준비된 엔진에서 delete 메서드만 실행하여 시간 측정
             |mut engine| {
-                engine.delete_document(black_box(&delete_id)).unwrap();
+                engine.delete_document(black_box(&delete_id));
             }
         );
     });

--- a/src/models/errors.rs
+++ b/src/models/errors.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, PartialEq)]
+pub enum VectorEngineError {
+    DimensionMismatch(String),
+    SerializationError(String),
+    DeserializationError(String),
+    ItemNotFound(String),
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,7 +1,9 @@
 pub mod document;
 pub mod engine;
 pub mod search_cache;
+pub mod errors;
 
 pub use document::Document;
 pub use engine::VectorEngine;
 pub use search_cache::{SearchCache, CacheStats};
+pub use errors::VectorEngineError;


### PR DESCRIPTION
### 📝 개요 (Overview)
> 이번 PR의 목표는 무엇인가요? 어떤 User Story를 해결하나요?
User Story: 개발자로서, 나는 VectorEngine의 메서드들이 단순 String이 아닌, 구조화된 에러 타입을 반환하도록 하여 TypeScript(호스트) 측에서 에러 종류에 따라 분기 처리를 용이하게 할 수 있어야 한다.


### 🔨 주요 변경 사항 (Key Changes)
> 구체적으로 어떤 파일에서 무엇을 변경했나요?

- models/errors.rs 파일 생성 후 VectorEngineError Enum 개체 생성
- engine.rs에 Result<(), String>을 모두 VectorEngineError을 사용하도록 변경
- tests/vector_engine_test.rs의 내용을 수정
- engine의 search()함수에 ef_search파라미터 추가


### ✅ 관련 이슈 또는 User Story
> 이 PR이 해결하는 칸반 보드의 User Story는 무엇인가요? (예: Closes: #이슈번호)

- Closes: **[스프린트 3]** 에러 핸들링 `E`


### 📸 스크린샷 또는 로그 (Screenshots or Logs)
> 테스트 결과나 UI 변경사항 등, 시각적으로 보여줄 수 있는 증거가 있나요?

```bash
running 13 tests
test test_vector_engine_delete_and_rebuild ... ok
test test_vector_engine_returns_item_not_found_on_delete ... ok
test test_vector_engine_add_document_success ... ok
test test_vector_engine_returns_dimension_mismatch_error ... ok
test test_vector_engine_returns_item_not_found_on_update ... ok
test test_vector_engine_round_trip ... ok
test test_vector_engine_add_document_dimension_mismatch ... ok
test test_vector_engine_creation ... ok
test test_vector_engine_search_after_cache_invalidation ... ok
test test_vector_engine_search_miss_and_hit ... ok
test test_vector_engine_search_on_empty_engine ... ok
test test_vector_engine_search_with_k_larger_than_docs ... ok
test test_vector_engine_update_document ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```